### PR TITLE
Add some flexibility to what values are included in the feed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 nbproject
 *.swp
 .bundle
+spec/dummy

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Then bundle
 bundle install
 ```
 
+Then (if you wish to customize the feed), install the config/initializers/google_merchant.rb file:
+
+```ruby
+rails g spree_google_merchant:install
+```
+
+You can view the initializer to get an idea how to customize things.
+
 Next, configure the feed title, description and site URL by browsing to the Google Merchant settings page in `Admin -> Configuration`
 
 Finally, set up your products in Spree by editing the product's properties.  You should add the following properties:

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,7 +1,57 @@
 module Spree
   ProductsController.class_eval do
+    helper_method :manager, :include_variants?, :in_stock, :properties
+
     def google_merchant
-      @products = Product.active
+      if include_variants?
+        @items = full_variants
+        @properties = GoogleMerchant::Manager.property_set(
+          @items.collect(&:product).uniq.sort_by(&:id)
+        )
+      else
+        @items = Product.active.includes(:variants)
+        @properties = GoogleMerchant::Manager.property_set(@items)
+      end
+      respond_to do |format|
+        format.any(:xml, :rss) { render formats: [:xml, :rss] }
+      end
+    end
+
+    private
+
+    def full_variants
+      t1 = Variant.arel_table
+      reflections = HashWithIndifferentAccess.new(Variant.reflections)
+      t2_name = "#{reflections[:first_non_master].plural_name}_#{t1.name}"
+      t2 = Arel::Table.new(t2_name)
+
+      Variant.active.where(
+        t1[:is_master].eq(false).or(t2[:id].eq(nil))
+      ).includes(
+        :product,
+        :advertising_image,
+        :default_price,
+        :stock_items,
+        :master,
+        :first_non_master,
+        {option_values: :option_type}
+      ).references(t2_name)
+    end
+
+    def manager
+      @manager ||= GoogleMerchant::Manager
+    end
+
+    def include_variants?
+      manager.include_variants?
+    end
+
+    def in_stock
+      @in_stock ||= Variant.in_stock.pluck(:id)
+    end
+
+    def properties
+      @properties
     end
   end
 end

--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -1,0 +1,30 @@
+module Spree
+  ProductsHelper.class_eval do
+    def google_merchant_tag(xml, key, value)
+      return unless value.present?
+      if value.respond_to?(:keys)
+        xml.tag!("g:#{key}") { nested_google_merchant_tag(xml, value) }
+      else
+        xml.tag! "g:#{key}", value
+      end
+    end
+
+    def nested_google_merchant_tag(xml, group)
+      group.each do |sub_key, sub_value|
+        google_merchant_tag(xml, sub_key, sub_value)
+      end
+    end
+
+    def feed_title
+      manager.feed_title
+    end
+
+    def feed_description
+      manager.feed_description
+    end
+
+    def production_domain
+      manager.production_domain
+    end
+  end
+end

--- a/app/models/spree/product_property_decorator.rb
+++ b/app/models/spree/product_property_decorator.rb
@@ -1,0 +1,23 @@
+module Spree
+  ProductProperty.class_eval do
+    scope :google_properties, ->{
+      select(
+        "#{table_name}.*, #{property_table_name}.name"
+      ).joins(
+        :property
+      ).where(
+        property_id: google_merchant_property_ids
+      )
+    }
+
+    private
+
+    def self.property_table_name
+      Property.table_name
+    end
+
+    def self.google_merchant_property_ids
+      GoogleMerchant::Manager.property_ids
+    end
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  Variant.class_eval do
+    has_one(
+      :advertising_image,
+      Spree::GoogleMerchant::Manager.advertising_image_proc,
+      as: :viewable,
+      class_name: "Spree::Image"
+    )
+    has_one :master, ->{ where(is_master: true) }, primary_key: :product_id, foreign_key: :product_id, class_name: "Spree::Variant"
+    has_one :first_non_master, ->{ where(is_master: false).order(:id) }, primary_key: :product_id, foreign_key: :product_id, class_name: "Spree::Variant"
+
+    def advertising_image_url
+      advertising_image.try(:attachment).try(:url, :product)
+    end
+  end
+end

--- a/app/views/spree/products/_product_attributes.rss.builder
+++ b/app/views/spree/products/_product_attributes.rss.builder
@@ -1,30 +1,16 @@
 # docs: https://support.google.com/merchants/answer/188494?hl=en
 
-google_merchant_product_category = Spree::Property.where(name: "google_merchant_product_category").first
-google_merchant_brand            = Spree::Property.where(name: "google_merchant_brand").first
-google_merchant_department       = Spree::Property.where(name: "google_merchant_department").first
-google_merchant_color            = Spree::Property.where(name: "google_merchant_color").first
-google_merchant_gtin             = Spree::Property.where(name: "google_merchant_gtin").first
-
-category   = variant.product.product_properties.where(property_id: google_merchant_product_category.id).first if google_merchant_product_category
-brand      = variant.product.product_properties.where(property_id: google_merchant_brand.id).first            if google_merchant_brand
-department = variant.product.product_properties.where(property_id: google_merchant_department.id).first       if google_merchant_department
-color      = variant.product.product_properties.where(property_id: google_merchant_color.id).first            if google_merchant_color
-gtin       = variant.product.product_properties.where(property_id: google_merchant_gtin.id).first             if google_merchant_gtin
-
-xml.title "#{variant.product.name} #{variant_options variant}"
-xml.description variant.product.description
-xml.link @production_domain + 'products/' + variant.product.slug
-xml.tag! "sku", variant.sku.to_s
-xml.tag! "brand", brand.value if brand
-xml.tag! "department", department.value if department
-xml.tag! "image", variant.product.images.first.attachment.url(:product) unless variant.product.images.empty?
-xml.tag! "color", color.value if color
-xml.tag! "GTIN", gtin.value if gtin
-xml.tag! "g:price", variant.price
-xml.tag! "g:google_product_category", category.value if category
-xml.tag! "g:product_type", category.value if category
 xml.tag! "g:id", variant.sku.to_s
+xml.tag! "g:title", manager.title(variant)
+xml.tag! "g:description", variant.product.description
+xml.tag! "g:link", production_domain + manager.variant_path(variant)
+xml.tag! "g:image_link", variant.advertising_image_url.gsub(/^\//, 'http:/') if variant.advertising_image
 xml.tag! "g:condition", "new"
-xml.tag! "g:availability", Spree::Stock::Quantifier.new(variant).total_on_hand > 0 ? 'in stock' : 'out of stock'
-xml.tag! "shipping_weight", variant.weight.to_s
+xml.tag! "g:availability", in_stock.include?(variant.id) ? 'in stock' : 'out of stock'
+xml.tag! "g:price", "#{variant.default_price.display_amount.money} #{variant.default_price.currency}"
+xml.tag! "g:mpn", variant.sku.to_s
+xml.tag! "g:shipping_weight", "#{variant.weight} #{manager.weight_unit}"
+xml.tag! "g:item_group_id", variant.master.sku.to_s if include_variants?
+properties[variant.product].merge(manager.option_values_for(variant)).each do |key, value|
+  google_merchant_tag(xml, key, value)
+end

--- a/app/views/spree/products/google_merchant.rss.builder
+++ b/app/views/spree/products/google_merchant.rss.builder
@@ -2,24 +2,16 @@ xml.instruct! :xml, :version=>"1.0", :encoding=>"UTF-8"
 
 xml.rss "version" => "2.0", "xmlns:g" => "http://base.google.com/ns/1.0" do
   xml.channel do
-    xml.title Spree::GoogleMerchant::Config[:google_merchant_title]
-    xml.description Spree::GoogleMerchant::Config[:google_merchant_description]
+    xml.title feed_title
+    xml.description feed_description
 
-    @production_domain = Spree::GoogleMerchant::Config[:production_domain]
-    xml.link @production_domain
+    xml.link production_domain
 
-    @products.each do |product|
-      # if product.google_merchant_include_variants
-      #   product.variants.each do |variant|
-      #     xml.item do
-      #       xml << render(:partial => 'product_attributes', :locals => { :variant => variant })
-      #     end
-      #   end
-      # else
-        xml.item do
-          xml << render(:partial => 'product_attributes', :locals => { :variant => product.master })
-        end
-      # end
+    @items.each do |item|
+      locals = { variant: (include_variants? ? item : item.master) }
+      xml.item do
+        xml << render(partial: 'product_attributes', locals: locals)
+      end
     end
   end
 end

--- a/lib/generators/spree_google_merchant/install/install_generator.rb
+++ b/lib/generators/spree_google_merchant/install/install_generator.rb
@@ -1,0 +1,73 @@
+module SpreeGoogleMerchant
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+
+      def add_initializer
+        create_file "config/initializers/google_merchant.rb", <<-FILE
+# Override the manager:
+# module Spree
+#   module GoogleMerchant
+#     class CustomProductManager < ProductManager
+#       # Override methods:
+#       def variant_path(variant)
+#         'products/' + variant.product.slug
+#       end
+#
+#       .
+#       .
+#       .
+#
+#     end
+#
+#     send(:remove_const, :Manager)
+#     Manager = CustomProductManager.new
+#   end
+# end
+
+
+Spree::GoogleMerchant::Manager.tap do |config|
+  # config.include_variants = false
+
+  # Replace/add to/remove from product_mapping.
+  # default is {
+  #   google_merchant_product_category: "google_product_category",
+  #   google_merchant_brand: "brand",
+  #   google_merchant_department: "department",
+  #   google_merchant_color: "color",
+  #   google_merchant_gtin: "gtin"
+  # }
+
+  # config.product_mapping.delete(:google_merchant_product_category)
+
+  # config.product_mapping.merge!(
+  #   material: "material"
+  # )
+
+  # Set a variant_mapping.
+  # config.variant_mapping = {
+  #   'my-color' => 'color',
+  #   .
+  #   .
+  #   .
+  # }
+
+  # Set fallback values for values that don't change across products.
+  # config.product_fallbacks = {
+  #   brand: 'My Brand',
+  #   .
+  #   .
+  #   .
+  # }
+
+  # Customize what's considered "the first image".
+  # config.advertising_image_proc = ->{ where(<something>).order(:position) }
+
+  # Set the units used for weight. Valid values are: lb, oz, g, or kg
+  # config.weight_unit = 'lb'
+end
+        FILE
+      end
+
+    end
+  end
+end

--- a/lib/spree/google_merchant/product_manager.rb
+++ b/lib/spree/google_merchant/product_manager.rb
@@ -1,0 +1,116 @@
+module Spree
+  module GoogleMerchant
+    class ProductManager
+      include Spree::BaseHelper
+
+      DEFAULT_MAPPING = {
+        google_merchant_product_category: "google_product_category",
+        google_merchant_brand: "brand",
+        google_merchant_department: "department",
+        google_merchant_color: "color",
+        google_merchant_gtin: "gtin"
+      }
+
+      VALID_WEIGHT_UNITS = %w(lb oz g kg)
+
+      attr_accessor :product_fallbacks, :advertising_image_proc, :weight_unit
+      attr_writer :include_variants
+      attr_reader :product_mapping, :variant_mapping
+
+      def initialize
+        @product_mapping = HashWithIndifferentAccess.new(DEFAULT_MAPPING)
+        @product_fallbacks = {}
+        @variant_mapping = {}
+        @include_variants = false
+        @advertising_image_proc = ->{order(:position)}
+        @weight_unit = VALID_WEIGHT_UNITS.first
+      end
+
+      def product_mapping=(hash)
+        @product_mapping = HashWithIndifferentAccess.new(hash)
+      end
+
+      def variant_mapping=(hash)
+        @variant_mapping = HashWithIndifferentAccess.new(hash)
+      end
+
+      def product_keys
+        product_mapping.keys
+      end
+
+      def variant_keys
+        variant_mapping.keys
+      end
+
+      def include_variants?
+        @include_variants.present?
+      end
+
+      def property_ids
+        Spree::Property.where(name: product_keys)
+      end
+
+      def property_set(products)
+        lookup_properties
+        products.inject(HashWithIndifferentAccess.new) do |set, product|
+          set.merge(product => properties_for(product))
+        end
+      end
+
+      def option_values_for(variant)
+        all_values = options_for(variant).inject({}) do |x,k|
+          x.merge(k.option_type.name => k)
+        end
+        variant_keys.inject(HashWithIndifferentAccess.new) do |values, key|
+          value = all_values[key].try(:presentation)
+          value ? values.merge(variant_mapping[key] => value) : values
+        end
+      end
+
+      def variant_path(variant)
+        'products/' + variant.product.slug
+      end
+
+      def title(variant)
+        "#{variant.product.name} #{variant_options variant}"
+      end
+
+      def feed_title
+        Spree::GoogleMerchant::Config[:google_merchant_title]
+      end
+
+      def feed_description
+        Spree::GoogleMerchant::Config[:google_merchant_description]
+      end
+
+      def production_domain
+        Spree::GoogleMerchant::Config[:production_domain]
+      end
+
+      private
+
+      attr_reader :properties
+
+      def lookup_properties
+        @properties = Spree::ProductProperty.google_properties.inject(
+          Hash.new { [] }
+        ) do |set, pp|
+          id = pp.product_id
+          set.merge(id => set[id] << pp)
+        end
+      end
+
+      def properties_for(product)
+        properties[product.id].inject(
+          HashWithIndifferentAccess.new(product_fallbacks)
+        ) do |set, pp|
+          set.merge(product_mapping[pp.name] => pp.value)
+        end
+      end
+
+      def options_for(variant)
+        variant.option_values.select { |ov| ov.option_type.name.in?(variant_keys) }
+      end
+    end
+  end
+end

--- a/lib/spree_google_merchant.rb
+++ b/lib/spree_google_merchant.rb
@@ -10,6 +10,7 @@ module SpreeGoogleMerchant
 
     initializer "spree.google_merchant.preferences", :before => :load_config_initializers do |app|
       Spree::GoogleMerchant::Config = Spree::GoogleMerchantConfiguration.new
+      Spree::GoogleMerchant::Manager = Spree::GoogleMerchant::ProductManager.new
     end
 
     def self.activate

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -11,10 +11,30 @@ describe Spree::ProductsController do
       allow(controller).to receive(:spree_current_user) { user }
     end
 
-    it 'sets @products instance variable' do
+    it 'sets the right instance variable' do
       spree_get :google_merchant, format: :rss
-      expect(assigns(:products)).to_not be_nil
-      expect(assigns(:products).first).to eql(product)
+      expect(assigns(:items)).to_not be_nil
+      expect(assigns(:items).first).to eql(product)
+    end
+
+    context 'with full_variants set' do
+      before do
+        Spree::GoogleMerchant::Manager.include_variants = true
+      end
+
+      it 'sets the right instance variable with only master variants' do
+        spree_get :google_merchant, format: :rss
+
+        expect(assigns(:items).first).to eql(product.master)
+      end
+
+      it 'sets the right instance variable with multiple variants' do
+        variant = create(:variant, product: product)
+
+        spree_get :google_merchant, format: :rss
+
+        expect(assigns(:items).first).to eql(variant)
+      end
     end
 
     it 'renders the proper RSS template' do

--- a/spec/features/customization_spec.rb
+++ b/spec/features/customization_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+feature :customization do
+  stub_authorization!
+
+  background do
+    reset_manager
+    sign_in_as! create(:admin_user)
+    Spree::GoogleMerchant::ProductManager::DEFAULT_MAPPING.each do |key, value|
+      create(:property, name: key.to_s, presentation: value.tr('_', ' ').titleize)
+    end
+    create(:property, name: 'my_brand', presentation: 'My Brand')
+    create(:option_type, name: 'variant_brand', presentation: 'Variant Brand')
+    create(:product, available_on: 1.year.ago).tap do |product|
+      Spree::Property.all.each do |property|
+        create(:product_property, product: product, property: property, value: property.presentation)
+      end
+      create(:variant, product: product).tap do |variant|
+        Spree::OptionType.all.each do |type|
+          variant.option_values.create(
+            option_type: type, name: "v_#{type.name}", presentation: "V: #{type.presentation}"
+          )
+        end
+      end
+    end
+  end
+
+  after do
+    reset_manager
+  end
+
+  context 'with product_mapping' do
+    it 'can remove a key' do
+      expect {
+        Spree::GoogleMerchant::Manager.product_mapping.delete(:google_merchant_brand)
+      }.to change {
+        visit '/google_merchant.rss'; page.body
+      }.from(
+        /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+      ).to(
+        /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+      )
+    end
+
+    it 'can replace a key' do
+      expect {
+        Spree::GoogleMerchant::Manager.product_mapping.delete(:google_merchant_brand)
+        Spree::GoogleMerchant::Manager.product_mapping[:my_brand] = "replaced_brand"
+      }.to change {
+        visit '/google_merchant.rss'; page.body
+      }.from(
+        /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+      ).to(
+        /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>\n<g:replaced_brand>My Brand<\/g:replaced_brand>/
+      )
+    end
+
+    it 'can default a key for all products' do
+      expect {
+        Spree::GoogleMerchant::Manager.product_mapping.delete(:google_merchant_brand)
+        Spree::GoogleMerchant::Manager.product_fallbacks[:brand] = "Not In the Database"
+      }.to change {
+        visit '/google_merchant.rss'; page.body
+      }.from(
+        /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+      ).to(
+        /<g:brand>Not In the Database<\/g:brand>\n<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+      )
+    end
+
+    context "showing variants" do
+      before do
+        Spree::GoogleMerchant::Manager.include_variants = true
+      end
+
+      it "can be overriden by variant values" do
+        expect {
+          Spree::GoogleMerchant::Manager.variant_mapping[:variant_brand] = "brand"
+        }.to change {
+          visit '/google_merchant.rss'; page.body
+        }.from(
+          /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>/
+        ).to(
+          /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>V: Variant Brand<\/g:brand>/
+        )
+      end
+
+      it "can add keys from the variant" do
+        expect {
+          Spree::GoogleMerchant::Manager.variant_mapping[:variant_brand] = "alt_brand"
+        }.to change {
+          visit '/google_merchant.rss'; page.body
+        }.from(
+          /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>/
+        ).to(
+          /<g:google_product_category>Google Product Category<\/g:google_product_category>\n<g:brand>Brand<\/g:brand>\n<g:department>Department<\/g:department>\n<g:color>Color<\/g:color>\n<g:gtin>Gtin<\/g:gtin>\n<g:alt_brand>V: Variant Brand<\/g:alt_brand>/
+        )
+      end
+    end
+  end
+
+  def reset_manager
+    Spree::GoogleMerchant::Manager.product_mapping = Spree::GoogleMerchant::ProductManager::DEFAULT_MAPPING
+    Spree::GoogleMerchant::Manager.product_fallbacks = {}
+    Spree::GoogleMerchant::Manager.variant_mapping = {}
+    Spree::GoogleMerchant::Manager.include_variants = false
+    Spree::GoogleMerchant::Manager.advertising_image_proc = ->{order(:position)}
+    Spree::GoogleMerchant::Manager.weight_unit = Spree::GoogleMerchant::ProductManager::VALID_WEIGHT_UNITS.first
+  end
+end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -6,11 +6,11 @@ feature :products do
   background do
     sign_in_as! create(:admin_user)
     create(:product, available_on: 1.year.ago)
-    visit '/google_merchant.rss'
   end
 
-  context :show, js: true do
+  context 'show rss', js: true do
     it 'shows the RSS feed' do
+      visit '/google_merchant.rss'
       xml = Nokogiri::XML(page.body)
 
       # ensure 1 product
@@ -23,6 +23,18 @@ feature :products do
       expect(xml.css("rss").first.css('title').first.children.first.text).to eql(Spree::GoogleMerchant::Config.google_merchant_title)
       expect(xml.css("rss").first.css('description').first.children.first.text).to eql(Spree::GoogleMerchant::Config.google_merchant_description)
       expect(xml.css("rss").first.css('link').first.children.first.text).to eql(Spree::GoogleMerchant::Config.production_domain)
+    end
+  end
+
+  context 'show xml', js: true do
+    it 'shows the same content for the XML feed' do
+      visit '/google_merchant.rss'
+      rss = page.body
+
+      visit '/google_merchant.xml'
+      xml = page.body
+
+      expect(xml).to eq(rss)
     end
   end
 end


### PR DESCRIPTION
Add an install generator to create a customizable initializer.
Include master variants if they are the only variant.
Allow for .rss and .xml formats.
Add shipping weight units (required by docs).
Add http: to image urls that don't have it (required by docs).
Change format of the price.
Replace SKU with MPN.
Add caching/eager loading.
Break out Variant/Product processing into separate paths.
Tweak in stock processing to allow it to be more performant.
